### PR TITLE
Update action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,5 +9,5 @@ inputs:
     description: "Switch Xcode to the given version"
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'main.js'


### PR DESCRIPTION
In order to address a warning with xcode-select-version action using a soon to be unsupported version of Node.

Link: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

This addresses: https://github.com/MobileDevOps/xcode-select-version-action/issues/2

### Type of change

- [X] bug fix
- [ ] new feature
- [ ] code style / documentation

### What does this implement/fix? Explain your changes.

1. Updated the action.yml to raise the node version from node16 to node20

